### PR TITLE
Port Raudi to python_on_whales

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -85,7 +85,7 @@ ipython_config.py
 # pyenv
 #   For a library or package, you might want to ignore these files since the code is
 #   intended to run in multiple environments; otherwise, check them in:
-# .python-version
+.python-version
 
 # pipenv
 #   According to pypa/pipenv#598, it is recommended to include Pipfile.lock in version control.

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,76 @@
+# Contributor Covenant Code of Conduct
+
+## Our Pledge
+
+In the interest of fostering an open and welcoming environment, we as
+contributors and maintainers pledge to making participation in our project and
+our community a harassment-free experience for everyone, regardless of age, body
+size, disability, ethnicity, sex characteristics, gender identity and expression,
+level of experience, education, socio-economic status, nationality, personal
+appearance, race, religion, or sexual identity and orientation.
+
+## Our Standards
+
+Examples of behavior that contributes to creating a positive environment
+include:
+
+* Using welcoming and inclusive language
+* Being respectful of differing viewpoints and experiences
+* Gracefully accepting constructive criticism
+* Focusing on what is best for the community
+* Showing empathy towards other community members
+
+Examples of unacceptable behavior by participants include:
+
+* The use of sexualized language or imagery and unwelcome sexual attention or
+ advances
+* Trolling, insulting/derogatory comments, and personal or political attacks
+* Public or private harassment
+* Publishing others' private information, such as a physical or electronic
+ address, without explicit permission
+* Other conduct which could reasonably be considered inappropriate in a
+ professional setting
+
+## Our Responsibilities
+
+Project maintainers are responsible for clarifying the standards of acceptable
+behavior and are expected to take appropriate and fair corrective action in
+response to any instances of unacceptable behavior.
+
+Project maintainers have the right and responsibility to remove, edit, or
+reject comments, commits, code, wiki edits, issues, and other contributions
+that are not aligned to this Code of Conduct, or to ban temporarily or
+permanently any contributor for other behaviors that they deem inappropriate,
+threatening, offensive, or harmful.
+
+## Scope
+
+This Code of Conduct applies both within project spaces and in public spaces
+when an individual is representing the project or its community. Examples of
+representing a project or community include using an official project e-mail
+address, posting via an official social media account, or acting as an appointed
+representative at an online or offline event. Representation of a project may be
+further defined and clarified by project maintainers.
+
+## Enforcement
+
+Instances of abusive, harassing, or otherwise unacceptable behavior may be
+reported by contacting the project team at angelo.delicato@secsi.io. All
+complaints will be reviewed and investigated and will result in a response that
+is deemed necessary and appropriate to the circumstances. The project team is
+obligated to maintain confidentiality with regard to the reporter of an incident.
+Further details of specific enforcement policies may be posted separately.
+
+Project maintainers who do not follow or enforce the Code of Conduct in good
+faith may face temporary or permanent repercussions as determined by other
+members of the project's leadership.
+
+## Attribution
+
+This Code of Conduct is adapted from the [Contributor Covenant][homepage], version 1.4,
+available at https://www.contributor-covenant.org/version/1/4/code-of-conduct.html
+
+[homepage]: https://www.contributor-covenant.org
+
+For answers to common questions about this code of conduct, see
+https://www.contributor-covenant.org/faq

--- a/LOG.md
+++ b/LOG.md
@@ -10,9 +10,7 @@
 - secsi/nikto updated to version 20211231
 - secsi/retire updated to version 3.0.6
 - secsi/vim updated to version 8.2.4065
-- secsi/impacket updated to version 0_9_24
 
 ### [2022-01-13]
 - secsi/dorks-eye updated to version 20220108
 - secsi/vim updated to version 8.2.4072
-- secsi/impacket updated to version 0_9_24

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,5 @@
 docker>=5.0.3
+python-on-whales>=0.34.0
 art>=5.3
 argparse==1.4.0
 questionary>=1.10.0

--- a/tools/impacket/config.py
+++ b/tools/impacket/config.py
@@ -10,7 +10,7 @@ def get_config(organization, common_args):
 
     config = {
         'name': organization+'/'+DEFAULT_DIRNAME,
-        'version': api_results['GITHUB_INFO']['version'].replace("impacket_", ""), 
+        'version': api_results['GITHUB_INFO']['version'].replace("impacket_", "").replace("_","."), 
         'buildargs': {
             'PYTHON_ALPINE_VERSION': common_args['PYTHON_ALPINE_VERSION'],
             'DOWNLOAD_URL': api_results['GITHUB_INFO']['url'], 


### PR DESCRIPTION
This PR replaces the `docker-py` library with [python_on_whales](https://gabrieldemarmiesse.github.io/python-on-whales/).

Justification:
- `docker-py` does not (and possibly, will not) support Buildkit. Issue [#2230](https://github.com/docker/docker-py/issues/2230)
- Not having access to BuildKit means that `raudi.py` is restricted to using only the simplest Dockerfiles.
- For full details regarding the advatages of BuildKit please refer to the [blog post](https://www.docker.com/blog/advanced-dockerfiles-faster-builds-and-smaller-images-using-buildkit-and-multistage-builds/).
- Additionally, since `python_on_whales` is essentially a wrapper around Docker CLI, it is a lot simpler to implement & maintain ( for e.g. `check_if_docker_image_exists_local()` in `helper.py` is now just one line! )

Changes:
- I've updated `build()` & `push()` in `raudi.py` with the new syntax. I've tested the `build()` function & confirmed that it works correctly (see #20) - but I have not tested `push()`.
- In `helper.py` I updated the code in `check_if_docker_image_exists_local()` & `check_if_container_runs()`. Please mind my comments in the latter.
- While I added `python_on_whales` in `requirements.txt` I did not remove `docker`. This is merely to facilitate debugging & it should be removed before merging into `main`.

As far as I'm aware - that should be everything. Apologies if I missed something.