### PR TITLE
Add clean_version helper function

### DIFF
--- a/helper.py
+++ b/helper.py
@@ -227,11 +227,6 @@ def get_latest_gitlab_commit(owner, project):
         latest_commit_date = ''.join(date.split('-'))
         return latest_commit_date
         # https://gitlab.com/projects/:id/repository/archive?sha=<commid>
-
-        return {
-            'url' : "{}{}{}?sha={}".format(GITLAB_API['base'], id_project, GITLAB_API['archive'], commid),
-            'version': tag
-        }
     except Exception as e: 
         raise Errors.gitlab_request()
 
@@ -317,8 +312,8 @@ def create_tool_folder(tool_name, template):
 
 
 def clean_version(v):
-    v = v.replace('_', '.')
-    if v.startswith('v'):
-        return v[1:]
-
+    v = re.sub('[-_]', '.', v)
+    v = re.sub('[a-zA-Z]', '', v)
+    v = v.replace('..', '.')
+    v = v.strip('.')
     return v

--- a/helper.py
+++ b/helper.py
@@ -314,3 +314,11 @@ def get_list_templates():
 def create_tool_folder(tool_name, template):
     shutil.copytree('templates/'+template, 'tools/'+tool_name)
     shutil.copy('templates/DOCKERHUB.md', 'tools/'+tool_name+'/README.md')
+
+
+def clean_version(v):
+    v = v.replace('_', '.')
+    if v.startswith('v'):
+        return v[1:]
+
+    return v

--- a/helper.py
+++ b/helper.py
@@ -316,4 +316,5 @@ def clean_version(v):
     v = re.sub('[a-zA-Z]', '', v)
     v = v.replace('..', '.')
     v = v.strip('.')
+    v = v.strip()
     return v

--- a/templates/alpine-builder/config.py
+++ b/templates/alpine-builder/config.py
@@ -14,7 +14,7 @@ def get_config(organization, common_args):
     
     config = {
         'name': organization+'/'+DEFAULT_DIRNAME,
-        # 'version': api_results['NPM_VERSION'], # USE THE APPROPRIATE FN FROM ABOVE (see README for details)
+        # 'version': helper.clean_version(api_results['NPM_VERSION']), # USE THE APPROPRIATE FN FROM ABOVE (see README for details)
         'buildargs': {
             'LATEST_ALPINE_VERSION': common_args['LATEST_ALPINE_VERSION'],
             #'DOWNLOAD_URL': api_results['GITHUB_INFO']['url'], # USE THE APPROPRIATE FN FROM ABOVE (see README for details)

--- a/templates/alpine/config.py
+++ b/templates/alpine/config.py
@@ -9,6 +9,7 @@ def get_config(organization, common_args):
         #'GITHUB_INFO': helper.get_latest_github_release('<repo_name>', '<target_string>'),
         #'GITHUB_INFO': helper.get_latest_github_release_no_browser_download('<repo_name>'),
         #'GITHUB_INFO': helper.get_latest_github_tag_no_browser_download('<repo_name>'),
+        #'GITHUB_INFO': helper.get_latest_github_commit('<repo_name>'),
     }
     
     config = {

--- a/templates/alpine/config.py
+++ b/templates/alpine/config.py
@@ -14,7 +14,7 @@ def get_config(organization, common_args):
     
     config = {
         'name': organization+'/'+DEFAULT_DIRNAME,
-        # 'version': api_results['NPM_VERSION'], # USE THE APPROPRIATE FN FROM ABOVE (see README for details)
+        # 'version': helper.clean_version(api_results['NPM_VERSION']), # USE THE APPROPRIATE FN FROM ABOVE (see README for details)
         'buildargs': {
             'LATEST_ALPINE_VERSION': common_args['LATEST_ALPINE_VERSION'],
             #'DOWNLOAD_URL': api_results['GITHUB_INFO']['url'], # USE THE APPROPRIATE FN FROM ABOVE (see README for details)

--- a/templates/debian/config.py
+++ b/templates/debian/config.py
@@ -12,7 +12,7 @@ def get_config(organization, common_args):
     }
     config = {
         'name': organization+'/'+DEFAULT_DIRNAME,
-        # 'version': api_results['GITHUB_INFO']['version'], # USE THE APPROPRIATE FN FROM ABOVE (see README for details)
+        # 'version': helper.clean_version(api_results['GITHUB_INFO']['version']), # USE THE APPROPRIATE FN FROM ABOVE (see README for details)
         'buildargs': {
             'DEBIAN_SLIM_VERSION': common_args['DEBIAN_SLIM_VERSION'],
             #'DOWNLOAD_URL': api_results['GITHUB_INFO']['url'], # USE THE APPROPRIATE FN FROM ABOVE (see README for details)

--- a/templates/go/config.py
+++ b/templates/go/config.py
@@ -13,7 +13,7 @@ def get_config(organization, common_args):
     
     config = {
         'name': organization+'/'+DEFAULT_DIRNAME,
-        # 'version': api_results['GITHUB_INFO']['version'], # USE THE APPROPRIATE FN FROM ABOVE (see README for details)
+        # 'version': helper.clean_version(api_results['GITHUB_INFO']['version']), # USE THE APPROPRIATE FN FROM ABOVE (see README for details)
         'buildargs': {
             'GOLANG_ALPINE_VERSION': common_args['GOLANG_ALPINE_VERSION'],
             'LATEST_ALPINE_VERSION': common_args['LATEST_ALPINE_VERSION'],

--- a/templates/java/config.py
+++ b/templates/java/config.py
@@ -13,7 +13,7 @@ def get_config(organization, common_args):
     
     config = {
         'name': organization+'/'+DEFAULT_DIRNAME,
-        # 'version': api_results['NPM_VERSION'], # USE THE APPROPRIATE FN FROM ABOVE (see README for details)
+        # 'version': helper.clean_version(api_results['NPM_VERSION']), # USE THE APPROPRIATE FN FROM ABOVE (see README for details)
         'buildargs': {
             'OPENJDK_ALPINE_VERSION': common_args['OPENJDK_ALPINE_VERSION'],
             #'DOWNLOAD_URL': api_results['GITHUB_INFO']['url'], # USE THE APPROPRIATE FN FROM ABOVE (see README for details)

--- a/templates/node/config.py
+++ b/templates/node/config.py
@@ -11,7 +11,7 @@ def get_config(organization, common_args):
     
     config = {
         'name': organization+'/'+DEFAULT_DIRNAME,
-        # 'version': api_results['NPM_VERSION'], # USE THE APPROPRIATE FN FROM ABOVE (see README for details)
+        # 'version': helper.clean_version(api_results['NPM_VERSION']), # USE THE APPROPRIATE FN FROM ABOVE (see README for details)
         'buildargs': {
             'NODE_ALPINE_VERSION': common_args['NODE_ALPINE_VERSION'],
             #'NPM_VERSION': api_results['RETIRE_NPM_VERSION'], # USE THE APPROPRIATE FN FROM ABOVE (see README for details)

--- a/templates/python/config.py
+++ b/templates/python/config.py
@@ -15,7 +15,7 @@ def get_config(organization, common_args):
 
     config = {
         'name': organization+'/'+DEFAULT_DIRNAME,
-        # 'version': api_results['GITHUB_INFO']['version'], # USE THE APPROPRIATE FN FROM ABOVE (see README for details)
+        # 'version': helper.clean_version(api_results['GITHUB_INFO']['version']), # USE THE APPROPRIATE FN FROM ABOVE (see README for details)
         'buildargs': {
             'PYTHON_ALPINE_VERSION': common_args['PYTHON_ALPINE_VERSION'],
             #'DOWNLOAD_URL': api_results['GITHUB_INFO']['url'], # USE THE APPROPRIATE FN FROM ABOVE (see README for details)

--- a/templates/python2/config.py
+++ b/templates/python2/config.py
@@ -14,7 +14,7 @@ def get_config(organization, common_args):
     
     config = {
         'name': organization+'/'+DEFAULT_DIRNAME,
-        # 'version': api_results['GITHUB_INFO']['version'], # USE THE APPROPRIATE FN FROM ABOVE (see README for details)
+        # 'version': helper.clean_version(api_results['GITHUB_INFO']['version']), # USE THE APPROPRIATE FN FROM ABOVE (see README for details)
         'buildargs': {
             'PYTHON2_ALPINE_VERSION': common_args['PYTHON2_ALPINE_VERSION'],
             #'DOWNLOAD_URL': api_results['GITHUB_INFO']['url'], # USE THE APPROPRIATE FN FROM ABOVE (see README for details)

--- a/templates/ruby/config.py
+++ b/templates/ruby/config.py
@@ -13,7 +13,7 @@ def get_config(organization, common_args):
 
     config = {
         'name': organization+'/'+DEFAULT_DIRNAME,
-        # 'version': api_results['GITHUB_INFO']['version'], # USE THE APPROPRIATE FN FROM ABOVE (see README for details)
+        # 'version': helper.clean_version(api_results['GITHUB_INFO']['version']), # USE THE APPROPRIATE FN FROM ABOVE (see README for details)
         'buildargs': {
             'RUBY_ALPINE_VERSION': common_args['RUBY_ALPINE_VERSION'],
             #'DOWNLOAD_URL': api_results['GITHUB_INFO']['url'], # USE THE APPROPRIATE FN FROM ABOVE (see README for details)

--- a/test/test_raudi.py
+++ b/test/test_raudi.py
@@ -92,3 +92,7 @@ def test_gitlab_id_by_project():
   exp = 7348427
   assert get_gitlab_id_project("netify.ai", "netify-agent") == exp
 
+
+def test_version_cleaner():
+  assert clean_version('v1.0') == '1.0'
+  assert clean_version('v1.2.3_4') == '1.2.3.4'

--- a/tools/altdns/config.py
+++ b/tools/altdns/config.py
@@ -7,7 +7,7 @@ def get_config(organization, common_args):
 
     config = {
         'name': organization+'/altdns',
-        'version': api_results['PIP_VERSION'],
+        'version': helper.clean_version(api_results['PIP_VERSION']),
         'buildargs': {
             'PYTHON_ALPINE_VERSION': common_args['PYTHON_ALPINE_VERSION'],
             'PIP_VERSION': api_results['PIP_VERSION'],

--- a/tools/apktool/config.py
+++ b/tools/apktool/config.py
@@ -6,7 +6,7 @@ def get_config(organization, common_args):
     
     config = {
         'name': organization+'/apktool',
-        'version': api_results['APKTOOL_GITHUB_INFO']['version'][1:], # Remove the leading 'v'
+        'version': helper.clean_version(api_results['APKTOOL_GITHUB_INFO']['version']),
         'buildargs': {
             'OPENJDK8_ALPINE_VERSION': common_args['OPENJDK8_ALPINE_VERSION'],
             'APKTOOL_DOWNLOAD_URL': api_results['APKTOOL_GITHUB_INFO']['url']

--- a/tools/arjun/config.py
+++ b/tools/arjun/config.py
@@ -7,7 +7,7 @@ def get_config(organization, common_args):
     
     config = {
         'name': organization+'/arjun',
-        'version': api_results['PIP_VERSION'],
+        'version': helper.clean_version(api_results['PIP_VERSION']),
         'buildargs': {
             'PYTHON_ALPINE_VERSION': common_args['PYTHON_ALPINE_VERSION'],
             'PIP_VERSION': api_results['PIP_VERSION']

--- a/tools/bfac/config.py
+++ b/tools/bfac/config.py
@@ -7,7 +7,7 @@ def get_config(organization, common_args):
 
     config = {
         'name': organization+'/bfac',
-        'version': api_results['BFAC_GITHUB_INFO']['version'][1:], # Remove the leading 'v'
+        'version': helper.clean_version(api_results['BFAC_GITHUB_INFO']['version']),
         'buildargs': {
             'PYTHON_ALPINE_VERSION': common_args['PYTHON_ALPINE_VERSION'],
             'BFAC_DOWNLOAD_URL': api_results['BFAC_GITHUB_INFO']['url']

--- a/tools/cloudfail/config.py
+++ b/tools/cloudfail/config.py
@@ -7,7 +7,7 @@ def get_config(organization, common_args):
 
     config = {
         'name': organization+'/cloudfail',
-        'version': api_results['GITHUB_INFO'],
+        'version': helper.clean_version(api_results['GITHUB_INFO']),
         'buildargs': {
             'PYTHON_ALPINE_VERSION': common_args['PYTHON_ALPINE_VERSION'],
             'DOWNLOAD_URL': "https://github.com/m0rtem/CloudFail.git"

--- a/tools/cmseek/config.py
+++ b/tools/cmseek/config.py
@@ -8,7 +8,7 @@ def get_config(organization, common_args):
 
     config = {
         'name': organization+'/cmseek',
-        'version': api_results['GITHUB_INFO']['version'][2:], # Remove the leading 'v.'
+        'version': helper.clean_version(api_results['GITHUB_INFO']['version']),
         'buildargs': {
             'PYTHON_ALPINE_VERSION': common_args['PYTHON_ALPINE_VERSION'],
             'CMSEEK_DOWNLOAD_URL': api_results['GITHUB_INFO']['url'],

--- a/tools/crowbar/config.py
+++ b/tools/crowbar/config.py
@@ -8,7 +8,7 @@ def get_config(organization, common_args):
 
     config = {
         'name': organization+'/crowbar',
-        'version': api_results['GITHUB_INFO']['version'][1:],
+        'version': helper.clean_version(api_results['GITHUB_INFO']['version']),
         'buildargs': {
             'PYTHON_ALPINE_VERSION': common_args['PYTHON_ALPINE_VERSION'],
             'DOWNLOAD_URL': api_results['GITHUB_INFO']['url'], 

--- a/tools/dalfox/config.py
+++ b/tools/dalfox/config.py
@@ -7,7 +7,7 @@ def get_config(organization, common_args):
     
     config = {
         'name': organization+'/dalfox',
-        'version': api_results['GITHUB_INFO']['version'][1:],
+        'version': helper.clean_version(api_results['GITHUB_INFO']['version']),
         'buildargs': {
             'GOLANG_ALPINE_VERSION': common_args['GOLANG_ALPINE_VERSION'],
         },

--- a/tools/datasploit/config.py
+++ b/tools/datasploit/config.py
@@ -8,7 +8,7 @@ def get_config(organization, common_args):
 
     config = {
         'name': organization + '/datasploit',
-        'version': api_results['DATASPLOIT_GITHUB_INFO'],
+        'version': helper.clean_version(api_results['DATASPLOIT_GITHUB_INFO']),
         'buildargs': {
             'PYTHON2_ALPINE_VERSION': common_args['PYTHON2_ALPINE_VERSION'],
             'DATASPLOIT_DOWNLOAD_URL':  "https://github.com/DataSploit/datasploit"

--- a/tools/dex2jar/config.py
+++ b/tools/dex2jar/config.py
@@ -8,7 +8,7 @@ def get_config(organization, common_args):
 
     config = {
         'name': organization + '/dex2jar',
-        'version': api_results['DEX2JAR_GITHUB_INFO']['version'][1:],
+        'version': helper.clean_version(api_results['DEX2JAR_GITHUB_INFO']['version']),
         'buildargs': {
             'OPENJDK8_ALPINE_VERSION': common_args['OPENJDK8_ALPINE_VERSION'],
             'DEX2JAR_DOWNLOAD_URL': api_results['DEX2JAR_GITHUB_INFO']['url']

--- a/tools/dirhunt/config.py
+++ b/tools/dirhunt/config.py
@@ -7,7 +7,7 @@ def get_config(organization, common_args):
     
     config = {
         'name': organization+'/dirhunt',
-        'version': api_results['DIRHUNT_PIP_VERSION'],
+        'version': helper.clean_version(api_results['DIRHUNT_PIP_VERSION']),
         'buildargs': {
             'PYTHON_ALPINE_VERSION': common_args['PYTHON_ALPINE_VERSION'],
             'DIRHUNT_VERSION': api_results['DIRHUNT_PIP_VERSION']

--- a/tools/dirsearch/config.py
+++ b/tools/dirsearch/config.py
@@ -7,7 +7,7 @@ def get_config(organization, common_args):
     
     config = {
         'name': organization+'/dirsearch',
-        'version': api_results['DIRSEARCH_GITHUB_INFO']['version'][1:], # Remove the leading 'v'
+        'version': helper.clean_version(api_results['DIRSEARCH_GITHUB_INFO']['version']),
         'buildargs': {
             'PYTHON_ALPINE_VERSION': common_args['PYTHON_ALPINE_VERSION'],
             'DIRSEARCH_DOWNLOAD_URL': api_results['DIRSEARCH_GITHUB_INFO']['url']

--- a/tools/dnscan/config.py
+++ b/tools/dnscan/config.py
@@ -7,7 +7,7 @@ def get_config(organization, common_args):
     
     config = {
         'name': organization+'/dnscan',
-        'version': api_results['DNSCAN_GITHUB_INFO'],
+        'version': helper.clean_version(api_results['DNSCAN_GITHUB_INFO']),
         'buildargs': {
             'PYTHON_ALPINE_VERSION': common_args['PYTHON_ALPINE_VERSION'],
             'DNSCAN_DOWNLOAD_URL': "https://github.com/rbsec/dnscan"

--- a/tools/dorks-eye/config.py
+++ b/tools/dorks-eye/config.py
@@ -7,7 +7,7 @@ def get_config(organization, common_args):
     
     config = {
         'name': organization+'/dorks-eye',
-        'version': api_results['GITHUB_COMMIT_DATE'],
+        'version': helper.clean_version(api_results['GITHUB_COMMIT_DATE']),
         'buildargs': {
             'PYTHON_ALPINE_VERSION': common_args['PYTHON_ALPINE_VERSION'],
             'DOWNLOAD_URL': "https://github.com/BullsEye0/dorks-eye"

--- a/tools/dvcs-ripper/config.py
+++ b/tools/dvcs-ripper/config.py
@@ -7,7 +7,7 @@ def get_config(organization, common_args):
     
     config = {
         'name': organization+'/dvcs-ripper',
-        'version': api_results['DVCRIPPER_GITHUB_INFO'],
+        'version': helper.clean_version(api_results['DVCRIPPER_GITHUB_INFO']),
         'buildargs': {
             'DEBIAN_SLIM_VERSION': common_args['DEBIAN_SLIM_VERSION'],
             'DVCRIPPER_DOWNLOAD_URL': "https://github.com/kost/dvcs-ripper"

--- a/tools/eyewitness/config.py
+++ b/tools/eyewitness/config.py
@@ -8,7 +8,7 @@ def get_config(organization, common_args):
 
     config = {
         'name': organization + '/eyewitness',
-        'version': api_results['EYEWITNESS_GITHUB_INFO']['version'][1:],
+        'version': helper.clean_version(api_results['EYEWITNESS_GITHUB_INFO']['version']),
         'buildargs': {
             'PYTHON_ALPINE_VERSION': common_args['PYTHON_ALPINE_VERSION'],
             'EYEWITNESS_DOWNLOAD_URL': api_results['EYEWITNESS_GITHUB_INFO']['url']

--- a/tools/fast-recon/config.py
+++ b/tools/fast-recon/config.py
@@ -7,7 +7,7 @@ def get_config(organization, common_args):
 
     config = {
         'name': organization+'/fast-recon',
-        'version': api_results['GITHUB_INFO'],
+        'version': helper.clean_version(api_results['GITHUB_INFO']),
         'buildargs': {
             'PYTHON_ALPINE_VERSION': common_args['PYTHON_ALPINE_VERSION'],
             'DOWNLOAD_URL': "https://github.com/DanMcInerney/fast-recon.git"

--- a/tools/ffuf/config.py
+++ b/tools/ffuf/config.py
@@ -7,7 +7,7 @@ def get_config(organization, common_args):
     
     config = {
         'name': organization+'/ffuf',
-        'version': api_results['FFUF_GITHUB_INFO']['version'][1:], # Remove the leading 'v'
+        'version': helper.clean_version(api_results['FFUF_GITHUB_INFO']['version']),
         'buildargs': {
             'LATEST_ALPINE_VERSION': common_args['LATEST_ALPINE_VERSION'],
             'FFUF_DOWNLOAD_URL': api_results['FFUF_GITHUB_INFO']['url']

--- a/tools/fierce/config.py
+++ b/tools/fierce/config.py
@@ -7,7 +7,7 @@ def get_config(organization, common_args):
     
     config = {
         'name': organization+'/fierce',
-        'version': api_results['FIERCE_GITHUB_INFO']['version'],
+        'version': helper.clean_version(api_results['FIERCE_GITHUB_INFO']['version']),
         'buildargs': {
             'PYTHON_ALPINE_VERSION': common_args['PYTHON_ALPINE_VERSION'],
             'FIERCE_DOWNLOAD_URL': api_results['FIERCE_GITHUB_INFO']['url']

--- a/tools/findsploit/config.py
+++ b/tools/findsploit/config.py
@@ -7,7 +7,7 @@ def get_config(organization, common_args):
 
     config = {
         'name': organization+'/findsploit',
-        'version': api_results['FINDSPLOIT_GITHUB_INFO']['version'][1:], # Remove the leading 'v'
+        'version': helper.clean_version(api_results['FINDSPLOIT_GITHUB_INFO']['version']),
         'buildargs': {
             'LATEST_ALPINE_VERSION': common_args['LATEST_ALPINE_VERSION'],
             'FINDSPLOIT_DOWNLOAD_URL': api_results['FINDSPLOIT_GITHUB_INFO']['url']

--- a/tools/getjs/config.py
+++ b/tools/getjs/config.py
@@ -7,7 +7,7 @@ def get_config(organization, common_args):
     
     config = {
         'name': organization+'/getjs',
-        'version': api_results['GITHUB_INFO'],
+        'version': helper.clean_version(api_results['GITHUB_INFO']),
         'buildargs': {
             'GOLANG_ALPINE_VERSION': common_args['GOLANG_ALPINE_VERSION'],
             'LATEST_ALPINE_VERSION': common_args['LATEST_ALPINE_VERSION'],

--- a/tools/gittools/config.py
+++ b/tools/gittools/config.py
@@ -8,7 +8,7 @@ def get_config(organization, common_args):
 
     config = {
         'name': organization + '/gittools',
-        'version': api_results['GITTOLS_GITHUB_INFO']['version'][1:],
+        'version': helper.clean_version(api_results['GITTOLS_GITHUB_INFO']['version']),
         'buildargs': {
             'PYTHON_ALPINE_VERSION': common_args['PYTHON_ALPINE_VERSION'],
             'GITTOLS_DOWNLOAD_URL': api_results['GITTOLS_GITHUB_INFO']['url']

--- a/tools/gobuster/config.py
+++ b/tools/gobuster/config.py
@@ -7,7 +7,7 @@ def get_config(organization, common_args):
     
     config = {
         'name': organization+'/gobuster',
-        'version': api_results['GOBUSTER_GITHUB_INFO']['version'][1:], # Remove the leading 'v'
+        'version': helper.clean_version(api_results['GOBUSTER_GITHUB_INFO']['version']),
         'buildargs': {
             'LATEST_ALPINE_VERSION': common_args['LATEST_ALPINE_VERSION'],
             'GOBUSTER_DOWNLOAD_URL': api_results['GOBUSTER_GITHUB_INFO']['url']

--- a/tools/googd0rker/config.py
+++ b/tools/googd0rker/config.py
@@ -7,7 +7,7 @@ def get_config(organization, common_args):
     
     config = {
         'name': organization+'/googd0rker',
-        'version': api_results['GOOGD0RKER_GITHUB_INFO'],
+        'version': helper.clean_version(api_results['GOOGD0RKER_GITHUB_INFO']),
         'buildargs': {
             'PYTHON_ALPINE_VERSION': common_args['PYTHON_ALPINE_VERSION'],
             'GOOGD0RKER_DOWNLOAD_URL': "https://github.com/ZephrFish/GoogD0rker"

--- a/tools/gospider/config.py
+++ b/tools/gospider/config.py
@@ -7,7 +7,7 @@ def get_config(organization, common_args):
     
     config = {
         'name': organization+'/gospider',
-        'version': api_results['GITHUB_INFO']['version'][1:],
+        'version': helper.clean_version(api_results['GITHUB_INFO']['version']),
         'buildargs': {
             'GOLANG_ALPINE_VERSION': common_args['GOLANG_ALPINE_VERSION'],
             'LATEST_ALPINE_VERSION': common_args['LATEST_ALPINE_VERSION'],

--- a/tools/ground-control/config.py
+++ b/tools/ground-control/config.py
@@ -10,7 +10,7 @@ def get_config(organization, common_args):
     
     config = {
         'name': organization+'/ground-control',
-        'version': api_results['GROUNDCONTROL_GITHUB_INFO'],
+        'version': helper.clean_version(api_results['GROUNDCONTROL_GITHUB_INFO']),
         'buildargs': {
             'RUBY2_ALPINE_VERSION': common_args['RUBY2_ALPINE_VERSION'],
             'DOWNLOAD_URL': "https://github.com/jobertabma/ground-control",

--- a/tools/hakrawler/config.py
+++ b/tools/hakrawler/config.py
@@ -7,7 +7,7 @@ def get_config(organization, common_args):
     
     config = {
         'name': organization+'/hakrawler',
-        'version': api_results['GITHUB_INFO']['version'],
+        'version': helper.clean_version(api_results['GITHUB_INFO']['version']),
         'buildargs': {
             'LATEST_ALPINE_VERSION': common_args['LATEST_ALPINE_VERSION'],
             'GOLANG_ALPINE_VERSION': common_args['GOLANG_ALPINE_VERSION'],

--- a/tools/hakrevdns/config.py
+++ b/tools/hakrevdns/config.py
@@ -7,7 +7,7 @@ def get_config(organization, common_args):
     
     config = {
         'name': organization+'/hakrevdns',
-        'version': api_results['GITHUB_INFO'],
+        'version': helper.clean_version(api_results['GITHUB_INFO']),
         'buildargs': {
             'GOLANG_ALPINE_VERSION': common_args['GOLANG_ALPINE_VERSION'],
             'LATEST_ALPINE_VERSION': common_args['LATEST_ALPINE_VERSION'],

--- a/tools/hashid/config.py
+++ b/tools/hashid/config.py
@@ -7,7 +7,7 @@ def get_config(organization, common_args):
 
     config = {
         'name': organization+'/hashid',
-        'version': api_results['PIP_VERSION'],
+        'version': helper.clean_version(api_results['PIP_VERSION']),
         'buildargs': {
             'PYTHON_ALPINE_VERSION': common_args['PYTHON_ALPINE_VERSION'],
             'PIP_VERSION': api_results['PIP_VERSION'],

--- a/tools/httprobe/config.py
+++ b/tools/httprobe/config.py
@@ -7,7 +7,7 @@ def get_config(organization, common_args):
     
     config = {
         'name': organization+'/httprobe',
-        'version': api_results['GITHUB_INFO']['version'][1:],
+        'version': helper.clean_version(api_results['GITHUB_INFO']['version']),
         'buildargs': {
             'GOLANG_ALPINE_VERSION': common_args['GOLANG_ALPINE_VERSION'],
             'LATEST_ALPINE_VERSION': common_args['LATEST_ALPINE_VERSION'],

--- a/tools/hydra/config.py
+++ b/tools/hydra/config.py
@@ -7,7 +7,7 @@ def get_config(organization, common_args):
     
     config = {
         'name': organization+'/hydra',
-        'version': api_results['HYDRA_GITHUB_INFO']['version'][1:], # Remove the leading 'v',
+        'version': helper.clean_version(api_results['HYDRA_GITHUB_INFO']['version']),
         'buildargs': {
             'LATEST_ALPINE_VERSION': common_args['LATEST_ALPINE_VERSION'],
             'HYDRA_DOWNLOAD_URL': api_results['HYDRA_GITHUB_INFO']['url']

--- a/tools/impacket/config.py
+++ b/tools/impacket/config.py
@@ -10,7 +10,7 @@ def get_config(organization, common_args):
 
     config = {
         'name': organization+'/'+DEFAULT_DIRNAME,
-        'version': api_results['GITHUB_INFO']['version'].replace("impacket_", "").replace("_","."), 
+        'version': helper.clean_version(api_results['GITHUB_INFO']['version']),
         'buildargs': {
             'PYTHON_ALPINE_VERSION': common_args['PYTHON_ALPINE_VERSION'],
             'DOWNLOAD_URL': api_results['GITHUB_INFO']['url'], 

--- a/tools/joomscan/config.py
+++ b/tools/joomscan/config.py
@@ -8,7 +8,7 @@ def get_config(organization, common_args):
 
     config = {
         'name': organization+'/joomscan',
-        'version': api_results['GITHUB_INFO']['version'],
+        'version': helper.clean_version(api_results['GITHUB_INFO']['version']),
         'buildargs': {
             'LATEST_ALPINE_VERSION': common_args['LATEST_ALPINE_VERSION'],
             'JOOMSCAN_DOWNLOAD_URL': api_results['GITHUB_INFO']['url'],

--- a/tools/jwt_tool/config.py
+++ b/tools/jwt_tool/config.py
@@ -7,7 +7,7 @@ def get_config(organization, common_args):
     
     config = {
         'name': organization+'/jwt_tool',
-        'version': api_results['JWT_TOOL_GITHUB_INFO']['version'][1:], # Remove the leading 'v'
+        'version': helper.clean_version(api_results['JWT_TOOL_GITHUB_INFO']['version']),
         'buildargs': {
             'PYTHON_ALPINE_VERSION': common_args['PYTHON_ALPINE_VERSION'],
             'JWT_TOOL_DOWNLOAD_URL': api_results['JWT_TOOL_GITHUB_INFO']['url']

--- a/tools/knockpy/config.py
+++ b/tools/knockpy/config.py
@@ -7,7 +7,7 @@ def get_config(organization, common_args):
     
     config = {
         'name': organization+'/knockpy',
-        'version': api_results['KNOCKPY_GITHUB_INFO']['version'],
+        'version': helper.clean_version(api_results['KNOCKPY_GITHUB_INFO']['version']),
         'buildargs': {
             'PYTHON_ALPINE_VERSION': common_args['PYTHON_ALPINE_VERSION'],
             'KNOCKPY_DOWNLOAD_URL': api_results['KNOCKPY_GITHUB_INFO']['url']

--- a/tools/lfisuite/config.py
+++ b/tools/lfisuite/config.py
@@ -7,7 +7,7 @@ def get_config(organization, common_args):
     
     config = {
         'name': organization+'/lfisuite',
-        'version': api_results['LFISUITE_GITHUB_INFO']['version'][1:], # Remove the leading 'v'
+        'version': helper.clean_version(api_results['LFISUITE_GITHUB_INFO']['version']),
         'buildargs': {
             'PYTHON2_ALPINE_VERSION': common_args['PYTHON2_ALPINE_VERSION'],
             'LFISUITE_DOWNLOAD_URL': api_results['LFISUITE_GITHUB_INFO']['url']

--- a/tools/linkfinder/config.py
+++ b/tools/linkfinder/config.py
@@ -7,7 +7,7 @@ def get_config(organization, common_args):
 
     config = {
         'name': organization+'/linkfinder',
-        'version': api_results['GITHUB_INFO'],
+        'version': helper.clean_version(api_results['GITHUB_INFO']),
         'buildargs': {
             'PYTHON_ALPINE_VERSION': common_args['PYTHON_ALPINE_VERSION'],
             'DOWNLOAD_URL': "https://github.com/GerbenJavado/LinkFinder.git",

--- a/tools/masscan/config.py
+++ b/tools/masscan/config.py
@@ -7,7 +7,7 @@ def get_config(organization, common_args):
     
     config = {
         'name': organization+'/masscan',
-        'version': api_results['MASSCAN_GITHUB_INFO']['version'],
+        'version': helper.clean_version(api_results['MASSCAN_GITHUB_INFO']['version']),
         'buildargs': {
             'LATEST_ALPINE_VERSION': common_args['LATEST_ALPINE_VERSION'],
             'MASSCAN_DOWNLOAD_URL': api_results['MASSCAN_GITHUB_INFO']['url']

--- a/tools/massdns/config.py
+++ b/tools/massdns/config.py
@@ -7,7 +7,7 @@ def get_config(organization, common_args):
     
     config = {
         'name': organization+'/massdns',
-        'version': api_results['MASSDNS_GITHUB_INFO']['version'][1:], # Remove the leading 'v'
+        'version': helper.clean_version(api_results['MASSDNS_GITHUB_INFO']['version']),
         'buildargs': {
             'LATEST_ALPINE_VERSION': common_args['LATEST_ALPINE_VERSION'],
             'MASSDNS_DOWNLOAD_URL': api_results['MASSDNS_GITHUB_INFO']['url']

--- a/tools/memcrashed/config.py
+++ b/tools/memcrashed/config.py
@@ -7,7 +7,7 @@ def get_config(organization, common_args):
 
     config = {
         'name': organization+'/memcrashed',
-        'version': api_results['GITHUB_INFO'],
+        'version': helper.clean_version(api_results['GITHUB_INFO']),
         'buildargs': {
             'PYTHON_ALPINE_VERSION': common_args['PYTHON_ALPINE_VERSION'],
             'DOWNLOAD_URL': "https://github.com/649/Memcrashed-DDoS-Exploit.git",

--- a/tools/netifyd/config.py
+++ b/tools/netifyd/config.py
@@ -4,13 +4,13 @@ import os
 DEFAULT_DIRNAME = os.path.basename(os.path.dirname(__file__))
 
 def version():
-    return helper.grep(helper.get_remote_resource('http://download.netify.ai/netify/debian/10/Packages'), 'Version:')[0].split(":")[1].strip().replace('-','.')
+    return helper.grep(helper.get_remote_resource('http://download.netify.ai/netify/debian/10/Packages'), 'Version:')[0].split(":")[1]
 
 def get_config(organization, common_args):
     
     config = {
         'name': organization+'/'+DEFAULT_DIRNAME,
-        'version': version(),
+        'version': helper.clean_version(version()),
         'buildargs': {
             'KEY_URL': 'http://download.netify.ai/netify/ubuntu/apt-gpg-key-netify.asc'
         },

--- a/tools/nikto/config.py
+++ b/tools/nikto/config.py
@@ -7,7 +7,7 @@ def get_config(organization, common_args):
     
     config = {
         'name': organization+'/nikto',
-        'version': api_results['NIKTO_GITHUB_INFO'],
+        'version': helper.clean_version(api_results['NIKTO_GITHUB_INFO']),
         'buildargs': {
             'LATEST_ALPINE_VERSION': common_args['LATEST_ALPINE_VERSION'],
             'NIKTO_DOWNLOAD_URL': "https://github.com/sullo/nikto"

--- a/tools/nmap/config.py
+++ b/tools/nmap/config.py
@@ -7,7 +7,7 @@ def get_config(organization, common_args):
     
     config = {
         'name': organization+'/nmap',
-        'version': api_results['NMAP_GITHUB_INFO'],
+        'version': helper.clean_version(api_results['NMAP_GITHUB_INFO']),
         'buildargs': {
             'LATEST_ALPINE_VERSION': common_args['LATEST_ALPINE_VERSION'],
             'NMAP_DOWNLOAD_URL': "https://github.com/nmap/nmap"

--- a/tools/oxml_xxe/config.py
+++ b/tools/oxml_xxe/config.py
@@ -10,7 +10,7 @@ def get_config(organization, common_args):
     
     config = {
         'name': organization+'/oxml_xxe',
-        'version': api_results['OXMLXXE_GITHUB_INFO'],
+        'version': helper.clean_version(api_results['OXMLXXE_GITHUB_INFO']),
         'buildargs': {
             'RUBY2_ALPINE_VERSION': common_args['RUBY2_ALPINE_VERSION'],
             'OXMLXXE_DOWNLOAD_URL': "https://github.com/BuffaloWill/oxml_xxe",

--- a/tools/pagodo/config.py
+++ b/tools/pagodo/config.py
@@ -7,7 +7,7 @@ def get_config(organization, common_args):
 
     config = {
         'name': organization+'/pagodo',
-        'version': api_results['GITHUB_INFO']['version'][1:],
+        'version': helper.clean_version(api_results['GITHUB_INFO']['version']),
         'buildargs': {
             'PYTHON_ALPINE_VERSION': common_args['PYTHON_ALPINE_VERSION'],
             'DOWNLOAD_URL': api_results['GITHUB_INFO']['url'],

--- a/tools/photon/config.py
+++ b/tools/photon/config.py
@@ -7,7 +7,7 @@ def get_config(organization, common_args):
 
     config = {
         'name': organization+'/photon',
-        'version': api_results['GITHUB_INFO']['version'][1:],
+        'version': helper.clean_version(api_results['GITHUB_INFO']['version']),
         'buildargs': {
             'PYTHON_ALPINE_VERSION': common_args['PYTHON_ALPINE_VERSION'],
             'DOWNLOAD_URL': api_results['GITHUB_INFO']['url'],

--- a/tools/pivotsuite/config.py
+++ b/tools/pivotsuite/config.py
@@ -7,7 +7,7 @@ def get_config(organization, common_args):
 
     config = {
         'name': organization+'/pivotsuite',
-        'version': api_results['PIP_VERSION'],
+        'version': helper.clean_version(api_results['PIP_VERSION']),
         'buildargs': {
             'PYTHON_ALPINE_VERSION': common_args['PYTHON_ALPINE_VERSION'],
             'PIP_VERSION': api_results['PIP_VERSION'],

--- a/tools/psalm/config.py
+++ b/tools/psalm/config.py
@@ -7,7 +7,7 @@ def get_config(organization, common_args):
     
     config = {
         'name': organization+'/psalm',
-        'version': api_results['GITHUB_INFO']['version'],
+        'version': helper.clean_version(api_results['GITHUB_INFO']['version']),
         'buildargs': {
             'PHP_ALPINE_VERSION': common_args['PHP_ALPINE_VERSION'],
             'DOWNLOAD_URL': api_results['GITHUB_INFO']['url'],

--- a/tools/puredns/config.py
+++ b/tools/puredns/config.py
@@ -7,7 +7,7 @@ def get_config(organization, common_args):
     
     config = {
         'name': organization+'/puredns',
-        'version': api_results['GITHUB_INFO']['version'][1:], # Remove the leading 'v'
+        'version': helper.clean_version(api_results['GITHUB_INFO']['version']),
         'buildargs': {
             'LATEST_ALPINE_VERSION': common_args['LATEST_ALPINE_VERSION'],
             'GOLANG_ALPINE_VERSION' : common_args['GOLANG_ALPINE_VERSION'],

--- a/tools/race-the-web/config.py
+++ b/tools/race-the-web/config.py
@@ -7,7 +7,7 @@ def get_config(organization, common_args):
     
     config = {
         'name': organization+'/race-the-web',
-        'version': api_results['RACETHEWEB_GITHUB_INFO']['version'],
+        'version': helper.clean_version(api_results['RACETHEWEB_GITHUB_INFO']['version']),
         'buildargs': {
             'LATEST_ALPINE_VERSION': common_args['LATEST_ALPINE_VERSION'],
             'RACETHEWEB_DOWNLOAD_URL': api_results['RACETHEWEB_GITHUB_INFO']['url']

--- a/tools/restfulharvest/config.py
+++ b/tools/restfulharvest/config.py
@@ -7,7 +7,7 @@ def get_config(organization, common_args):
     
     config = {
         'name': organization+'/restfulharvest',
-        'version': api_results['THEHARVESTER_GITHUB_INFO']['version'],
+        'version': helper.clean_version(api_results['THEHARVESTER_GITHUB_INFO']['version']),
         'buildargs': {
             'PYTHON_ALPINE_VERSION': common_args['PYTHON_ALPINE_VERSION'],
             'THEHARVESTER_DOWNLOAD_URL': api_results['THEHARVESTER_GITHUB_INFO']['url']

--- a/tools/retire/config.py
+++ b/tools/retire/config.py
@@ -7,7 +7,7 @@ def get_config(organization, common_args):
     
     config = {
         'name': organization+'/retire',
-        'version': api_results['RETIRE_NPM_VERSION'],
+        'version': helper.clean_version(api_results['RETIRE_NPM_VERSION']),
         'buildargs': {
             'NODE_ALPINE_VERSION': common_args['NODE_ALPINE_VERSION'],
             'RETIRE_NPM_VERSION': api_results['RETIRE_NPM_VERSION']

--- a/tools/routersploit/config.py
+++ b/tools/routersploit/config.py
@@ -7,7 +7,7 @@ def get_config(organization, common_args):
 
     config = {
         'name': organization+'/routersploit',
-        'version': api_results['GITHUB_INFO']['version'][1:],
+        'version': helper.clean_version(api_results['GITHUB_INFO']['version']),
         'buildargs': {
             'PYTHON_ALPINE_VERSION': common_args['PYTHON_ALPINE_VERSION'],
             'DOWNLOAD_URL': api_results['GITHUB_INFO']['url'],

--- a/tools/sandcastle/config.py
+++ b/tools/sandcastle/config.py
@@ -7,7 +7,7 @@ def get_config(organization, common_args):
     
     config = {
         'name': organization+'/sandcastle',
-        'version': api_results['SANDCASTLE_GITHUB_INFO']['version'],
+        'version': helper.clean_version(api_results['SANDCASTLE_GITHUB_INFO']['version']),
         'buildargs': {
             'PYTHON2_ALPINE_VERSION': common_args['PYTHON2_ALPINE_VERSION'],
             'SANDCASTLE_DOWNLOAD_URL': api_results['SANDCASTLE_GITHUB_INFO']['url']

--- a/tools/scanless/config.py
+++ b/tools/scanless/config.py
@@ -7,7 +7,7 @@ def get_config(organization, common_args):
 
     config = {
         'name': organization+'/scanless',
-        'version': api_results['PIP_VERSION'],
+        'version': helper.clean_version(api_results['PIP_VERSION']),
         'buildargs': {
             'PYTHON_ALPINE_VERSION': common_args['PYTHON_ALPINE_VERSION'],
             'PIP_VERSION': api_results['PIP_VERSION']

--- a/tools/spysepy/config.py
+++ b/tools/spysepy/config.py
@@ -7,7 +7,7 @@ def get_config(organization, common_args):
 
     config = {
         'name': organization+'/spysepy',
-        'version': api_results['PIP_VERSION'],
+        'version': helper.clean_version(api_results['PIP_VERSION']),
         'buildargs': {
             'PYTHON_ALPINE_VERSION': common_args['PYTHON_ALPINE_VERSION'],
             'PIP_VERSION': api_results['PIP_VERSION'],

--- a/tools/sqlmap/config.py
+++ b/tools/sqlmap/config.py
@@ -7,7 +7,7 @@ def get_config(organization, common_args):
     
     config = {
         'name': organization+'/sqlmap',
-        'version': api_results['SQLMAP_GITHUB_INFO']['version'],
+        'version': helper.clean_version(api_results['SQLMAP_GITHUB_INFO']['version']),
         'buildargs': {
             'PYTHON_ALPINE_VERSION': common_args['PYTHON_ALPINE_VERSION'],
             'SQLMAP_DOWNLOAD_URL': api_results['SQLMAP_GITHUB_INFO']['url']

--- a/tools/striker/config.py
+++ b/tools/striker/config.py
@@ -7,7 +7,7 @@ def get_config(organization, common_args):
 
     config = {
         'name': organization+'/striker',
-        'version': api_results['GITHUB_INFO'],
+        'version': helper.clean_version(api_results['GITHUB_INFO']),
         'buildargs': {
             'PYTHON_ALPINE_VERSION': common_args['PYTHON_ALPINE_VERSION'],
             'DOWNLOAD_URL': "https://github.com/s0md3v/Striker.git",

--- a/tools/subfinder/config.py
+++ b/tools/subfinder/config.py
@@ -7,7 +7,7 @@ def get_config(organization, common_args):
     
     config = {
         'name': organization+'/subfinder',
-        'version': api_results['SUBFINDER_GITHUB_INFO']['version'][1:],
+        'version': helper.clean_version(api_results['SUBFINDER_GITHUB_INFO']['version']),
         'buildargs': {
             'LATEST_ALPINE_VERSION': common_args['LATEST_ALPINE_VERSION'],
             'DOWNLOAD_URL': api_results['SUBFINDER_GITHUB_INFO']['url']

--- a/tools/subjack/config.py
+++ b/tools/subjack/config.py
@@ -7,7 +7,7 @@ def get_config(organization, common_args):
     
     config = {
         'name': organization+'/subjack',
-        'version': api_results['GITHUB_INFO']['version'],
+        'version': helper.clean_version(api_results['GITHUB_INFO']['version']),
         'buildargs': {
             'GOLANG_ALPINE_VERSION': common_args['GOLANG_ALPINE_VERSION'],
             'LATEST_ALPINE_VERSION': common_args['LATEST_ALPINE_VERSION'],

--- a/tools/sublist3r/config.py
+++ b/tools/sublist3r/config.py
@@ -7,7 +7,7 @@ def get_config(organization, common_args):
     
     config = {
         'name': organization+'/sublist3r',
-        'version': api_results['SUBLIST3R_GITHUB_INFO']['version'],
+        'version': helper.clean_version(api_results['SUBLIST3R_GITHUB_INFO']['version']),
         'buildargs': {
             'PYTHON_ALPINE_VERSION': common_args['PYTHON_ALPINE_VERSION'],
             'SUBLIST3R_DOWNLOAD_URL': api_results['SUBLIST3R_GITHUB_INFO']['url']

--- a/tools/theharvester/config.py
+++ b/tools/theharvester/config.py
@@ -7,7 +7,7 @@ def get_config(organization, common_args):
     
     config = {
         'name': organization+'/theharvester',
-        'version': api_results['THEHARVESTER_GITHUB_INFO']['version'],
+        'version': helper.clean_version(api_results['THEHARVESTER_GITHUB_INFO']['version']),
         'buildargs': {
             'PYTHON_ALPINE_VERSION': common_args['PYTHON_ALPINE_VERSION'],
             'THEHARVESTER_DOWNLOAD_URL': api_results['THEHARVESTER_GITHUB_INFO']['url']

--- a/tools/wafw00f/config.py
+++ b/tools/wafw00f/config.py
@@ -7,7 +7,7 @@ def get_config(organization, common_args):
 
     config = {
         'name': organization+'/wafw00f',
-        'version': api_results['GITHUB_INFO']['version'][1:], # Remove the leading 'v'
+        'version': helper.clean_version(api_results['GITHUB_INFO']['version']),
         'buildargs': {
             'PYTHON_ALPINE_VERSION': common_args['PYTHON_ALPINE_VERSION'],
             'DOWNLOAD_URL': api_results['GITHUB_INFO']['url']

--- a/tools/waybackpy/config.py
+++ b/tools/waybackpy/config.py
@@ -7,7 +7,7 @@ def get_config(organization, common_args):
     
     config = {
         'name': organization+'/waybackpy',
-        'version': api_results['WAYBACKPY_PIP_VERSION'],
+        'version': helper.clean_version(api_results['WAYBACKPY_PIP_VERSION']),
         'buildargs': {
             'PYTHON_ALPINE_VERSION': common_args['PYTHON_ALPINE_VERSION'],
             'WAYBACKPY_PIP_VERSION': api_results['WAYBACKPY_PIP_VERSION']

--- a/tools/whatweb/config.py
+++ b/tools/whatweb/config.py
@@ -7,7 +7,7 @@ def get_config(organization, common_args):
 
     config = {
         'name': organization+'/whatweb',
-        'version': api_results['WHATWEB_GITHUB_INFO']['version'][1:], # Remove the leading 'v'
+        'version': helper.clean_version(api_results['WHATWEB_GITHUB_INFO']['version']),
         'buildargs': {
             'RUBY_ALPINE_VERSION': common_args['RUBY_ALPINE_VERSION'],
             'WHATWEB_DOWNLOAD_URL': api_results['WHATWEB_GITHUB_INFO']['url']

--- a/tools/xray/config.py
+++ b/tools/xray/config.py
@@ -7,7 +7,7 @@ def get_config(organization, common_args):
     
     config = {
         'name': organization+'/xray',
-        'version': api_results['GITHUB_INFO'],
+        'version': helper.clean_version(api_results['GITHUB_INFO']),
         'buildargs': {
             'GOLANG_ALPINE_VERSION': common_args['GOLANG_ALPINE_VERSION'],
             'LATEST_ALPINE_VERSION': common_args['LATEST_ALPINE_VERSION'],

--- a/tools/xsser/config.py
+++ b/tools/xsser/config.py
@@ -3,12 +3,11 @@ import helper
 def get_config(organization, common_args):
     api_results = {
         'VERSION': helper.get_latest_github_commit('epsylon/xsser'),
-
     }
 
     config = {
         'name': organization+'/xsser',
-        'version': api_results['VERSION'],
+        'version': helper.clean_version(api_results['VERSION']),
         'buildargs': {
             'PYTHON_ALPINE_VERSION': common_args['PYTHON_ALPINE_VERSION'],
             'DOWNLOAD_URL': 'https://github.com/epsylon/xsser'

--- a/tools/xsssniper/config.py
+++ b/tools/xsssniper/config.py
@@ -7,7 +7,7 @@ def get_config(organization, common_args):
     
     config = {
         'name': organization+'/xsssniper',
-        'version': api_results['VERSION'],
+        'version': helper.clean_version(api_results['VERSION']),
         'buildargs': {
             'PYTHON2_ALPINE_VERSION': common_args['PYTHON2_ALPINE_VERSION'],
             'DOWNLOAD_URL': "https://github.com/gbrindisi/xsssniper"

--- a/tools/xsstrike/config.py
+++ b/tools/xsstrike/config.py
@@ -7,7 +7,7 @@ def get_config(organization, common_args):
 
     config = {
         'name': organization+'/xsstrike',
-        'version': api_results['GITHUB_INFO']['version'],
+        'version': helper.clean_version(api_results['GITHUB_INFO']['version']),
         'buildargs': {
             'PYTHON_ALPINE_VERSION': common_args['PYTHON_ALPINE_VERSION'],
             'DOWNLOAD_URL': api_results['GITHUB_INFO']['url'],

--- a/tools/xxeinjector/config.py
+++ b/tools/xxeinjector/config.py
@@ -10,7 +10,7 @@ def get_config(organization, common_args):
     
     config = {
         'name': organization+'/xxeinjector',
-        'version': api_results['XXEINJECTOR_GITHUB_INFO'],
+        'version': helper.clean_version(api_results['XXEINJECTOR_GITHUB_INFO']),
         'buildargs': {
             'RUBY_ALPINE_VERSION': common_args['RUBY_ALPINE_VERSION'],
             'DOWNLOAD_URL': "https://github.com/enjoiz/XXEinjector",


### PR DESCRIPTION
**Issue fixed**

This pull request fixes issue #3

**Changes proposed in this pull request**

Add a new helper function called ``clean_version`` that takes a version and *cleans* it into the format RAUDI expects (only digits and dots). The function has been added to the *templates* and to every other existing tool.